### PR TITLE
[Paper Addition] LeakSealer

### DIFF
--- a/Defenses.md
+++ b/Defenses.md
@@ -63,5 +63,6 @@
 |-------|----------|-------------------|------|-----------|
 | [AutoDefense: Multi-Agent LLM Defense against Jailbreak Attacks](https://arxiv.org/abs/2403.04783) | Multi-Agent Defense | A multi-agent framework that filters harmful responses from LLMs | ✅ | ✅ |
 | [Swiss Cheese Model for AI Safety: A Taxonomy and Reference Architecture for Multi-Layered Guardrails of Foundation Model Based Agents](https://arxiv.org/abs/2408.02205) | Multi-Layered Defense | A reference architecture inspired by the Swiss Cheese Model for designing multi-layered guardrails | ✅ | ✅ |
+| [LeakSealer: A Semisupervised Defense for LLMs Against Prompt Injection and Leakage Attacks](https://arxiv.org/abs/2508.00602) | Other Design Choices | A model-agnostic approach producing semantic fingerprints for adversarial prompts via clustering. | ❌ | ✅ |
 
 ---


### PR DESCRIPTION
# Description
This pull request adds [LeakSealer](https://arxiv.org/abs/2508.00602) to the taxonomy of LLM defenses.

## Note
For now, the defense is listed as non-Free, since the code has not yet been released while the paper is still under peer review. This property can be updated in a future PR once the code becomes publicly available.