### PR TITLE
Add ATBench to Evaluation & Benchmarks and AgentDoG to Defenses

### DIFF
--- a/Defenses.md
+++ b/Defenses.md
@@ -5,6 +5,7 @@
 |-------|----------|-------------------|------|-----------|
 | [OpenAI Moderation Endpoint](https://platform.openai.com/docs/guides/moderation/overview) | Guardrail | OpenAI Moderations Endpoint | ❌ | ✅ |
 | [A New Generation of Perspective API: Efficient Multilingual Character-level Transformers](https://api.semanticscholar.org/CorpusID:247058801) | Guardrail | Perspective API's Toxicity API | ❌ | ✅ |
+| [AgentDoG: A Diagnostic Guardrail Framework for AI Agent Safety and Security](https://arxiv.org/abs/2601.18491) | Guardrail | Trajectory-level diagnostic guardrail for tool-using agents | ✅ | ✅ |
 | [ToolSafe: Enhancing Tool Invocation Safety of LLM-based Agents via Proactive Step-level Guardrail and Feedback](https://arxiv.org/abs/2601.10156) | Guardrail | Step-level Guardrail for Tool Use Agent | ✅ | ✅ |
 | [Llama Guard: LLM-based Input-Output Safeguard for Human-AI Conversations](https://api.semanticscholar.org/CorpusID:266174345) | Guardrail | Llama Guard | ✅ | ✅ |
 | [Guardrails AI: Adding guardrails to large language models.](https://github.com/guardrails-ai/guardrails) | Guardrail | Guardrails AI Validators | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 ## Evaluation & Benchmarks
 | Title | Link |
 |-------|------|
+| ATBench: A Diverse and Realistic Agent Trajectory Benchmark for Safety Evaluation and Diagnosis | [Link](https://arxiv.org/abs/2604.02022) |
 | Beyond Uniform Criteria: Scenario-Adaptive Multi-Dimensional Jailbreak Evaluation (SceneJailEval) | [Link](https://arxiv.org/abs/2508.06194) |
 | NESSiE: The Necessary Safety Benchmark -- Identifying Errors that should not Exist | [Link](https://arxiv.org/abs/2602.16756) |
 


### PR DESCRIPTION
Hi! This PR adds two entries from our recent work on trajectory-level agent safety:

- **ATBench: A Diverse and Realistic Agent Trajectory Benchmark for Safety Evaluation and Diagnosis** to `Evaluation & Benchmarks`
- **AgentDoG: A Diagnostic Guardrail Framework for AI Agent Safety and Security** to `Defenses` under `Guardrail`

Links:
- ATBench paper: https://arxiv.org/abs/2604.02022
- ATBench dataset: https://huggingface.co/datasets/AI45Research/ATBench
- AgentDoG paper: https://arxiv.org/abs/2601.18491
- AgentDoG repo: https://github.com/AI45Lab/AgentDoG

Rationale:
- **ATBench** is a trajectory-level benchmark for evaluating and diagnosing safety risks in realistic tool-using agent trajectories.
- **AgentDoG** is a trajectory-level diagnostic guardrail framework for detecting and diagnosing risks in agent execution traces.

Happy to revise the wording or category placement if you prefer.